### PR TITLE
Add documentation folder with user and developer guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,7 @@ Round Trip Delay: 2.320 ms
 ```
 
 ---
+
+## Documentation
+
+See the [docs](docs/README.md) directory for the full user and developer guides.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# RKIK Documentation
+
+Welcome to the RKIK documentation. This directory contains guides for end users and developers working on the project.
+
+- [User Guide](user_guide.md)
+- [Developer Guide](developer_guide.md)

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -44,5 +44,11 @@ cargo test
 
 ## CI/CD
 
-GitHub Actions runs tests on each push. Packaging scripts for `.deb` and `.rpm` are defined in `Cargo.toml`.
+The workflow named `ci-test-n-build.yml` runs tests, lints, formats code and checks on dependencies on each push. All of that on 3 different OS using 
+matrix.
+
+There is another workflow `release.yaml` which is meant to build packages, binaries and artifacts and upload them to the 
+release page.
+
+Packaging scripts for `.deb` and `.rpm` are defined in `Cargo.toml`.
 

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,48 @@
+# Developer Guide
+
+This guide describes the project architecture and how to contribute.
+
+## Project Architecture
+
+RKIK is a Rust command-line application. The main logic lives in `src/lib.rs`, while `src/main.rs` contains the entry point.
+
+- **Argument Parsing**: Implemented with [`clap`](https://docs.rs/clap).
+- **NTP Client**: Provided by the [`rsntp`](https://crates.io/crates/rsntp) crate.
+- **Output**: Uses the `console` crate for coloured terminal output.
+
+## Code Structure
+
+```
+src/
+  main.rs  - CLI entry point
+  lib.rs   - Core functions: resolve_ip, query_server, compare_servers
+```
+
+Unit and CLI tests are in the `tests/` directory.
+
+## Environment Setup
+
+Ensure you have the latest stable Rust toolchain:
+
+```bash
+rustup install stable
+rustup default stable
+```
+
+Run tests with:
+
+```bash
+cargo test
+```
+
+## Contribution Guidelines
+
+1. Fork the repository and create your feature branch.
+2. Write tests for your changes.
+3. Ensure `cargo fmt` runs without modifying files.
+4. Submit a pull request and reference the relevant issue.
+
+## CI/CD
+
+GitHub Actions runs tests on each push. Packaging scripts for `.deb` and `.rpm` are defined in `Cargo.toml`.
+

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,11 +8,35 @@ This guide helps you install and use **RKIK** to query and compare NTP servers.
 
 Download the latest archive from the [releases page](https://github.com/aguacero7/rkik/releases/latest) and extract it:
 
+For linux :
 ```bash
 tar xvfz rkik-linux-x86_64.tar.gz
 sudo mv rkik /usr/local/bin
 ```
 
+You can also use the .exe on windows.
+
+### Install Packages
+There is among the release artifacts some pre-built packages for linux distributions which could in the future be part 
+in an official repository.
+
+- For Red-Hat based distros (CentOS, Fedora, ...) : `rkik-X.Y.Z-R.x86_64.rpm `
+
+Which can be installed by using
+```bash
+rpm -U rkik-X.Y.Z-R.x86_64.rpm
+# or 
+dnf install rkik-X.Y.Z-R.x86_64.rpm
+#or 
+yum install rkik-X.Y.Z-R.x86_64.rpm
+```
+
+- For Debian based distros (Debian, Ubuntu, Kali, ...) : `rkik_X.Y.Z-R_amd64.deb `
+
+You can simply install it with 
+```bash
+apt install rkik_X.Y.Z-R_amd64.deb
+```
 ### From Source
 
 ```bash

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,54 @@
+# User Guide
+
+This guide helps you install and use **RKIK** to query and compare NTP servers.
+
+## Installation
+
+### Prebuilt Binaries
+
+Download the latest archive from the [releases page](https://github.com/aguacero7/rkik/releases/latest) and extract it:
+
+```bash
+tar xvfz rkik-linux-x86_64.tar.gz
+sudo mv rkik /usr/local/bin
+```
+
+### From Source
+
+```bash
+git clone https://github.com/aguacero7/rkik.git
+cd rkik
+cargo build --release
+sudo cp target/release/rkik /usr/local/bin
+```
+
+## Configuration
+
+`rkik` has no persistent configuration. Use command line flags to control behaviour.
+
+## Usage
+
+Query an NTP server:
+
+```bash
+rkik pool.ntp.org
+```
+
+Compare two servers:
+
+```bash
+rkik --compare time.google.com time.cloudflare.com
+```
+
+Add `--verbose` to show stratum and reference ID, or `--format json` for JSON output.
+
+## Troubleshooting
+
+If you see network errors, ensure your firewall allows NTP traffic (UDP port 123) and that the server hostname resolves.
+
+## FAQ
+
+**Q:** Does RKIK support IPv6?
+
+**A:** Yes. Use the `--ipv6` flag when querying servers that have AAAA records.
+


### PR DESCRIPTION
## Summary
- create `docs/` folder with `user_guide.md` and `developer_guide.md`
- link documentation from the main README

Closes #5.

## Testing
- `cargo test` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686556c3a4408328906a63c48fc0ffb1