### PR TITLE
feat(async): Implement Async comparation between X Servers

### DIFF
--- a/.github/workflows/ci-test-n-build.yml
+++ b/.github/workflows/ci-test-n-build.yml
@@ -41,7 +41,7 @@ jobs:
 
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -A warnings
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           cargo install cargo-deb
           cargo install cargo-generate-rpm
           cargo install cross --locked
-          
+
 
       - name: Build release binary
         run: cargo build --release
@@ -65,7 +65,7 @@ jobs:
             target/generate-rpm/*.rpm
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - name: Publish to crates.io
         if: github.event.release.prerelease == false
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }} --allow-dirty
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,14 @@ readme = "README.md"
 keywords = ["ntp", "cli", "time", "network", "tool"]
 categories = ["command-line-utilities", "network-programming"]
 documentation = "https://docs.rs/rkik"
-
+include = [ #for CI to not publish artifacts
+    "Cargo.toml",
+    "Cargo.lock",
+    "README.md",
+    "LICENSE*",
+    "src/**",
+    "docs/**"
+]
 [features]
 default=[]
 network-tests = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ rsntp = "4.0.0"
 clap = { version = "4.5", features = ["derive"] }
 chrono = "0.4"
 console = "0.15"
+tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "net"] }
+futures = "0.3"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,10 @@
 use chrono::{DateTime, Local, Utc};
 use clap::Parser;
 use console::{Term, style};
-use rsntp::{Config, ReferenceIdentifier, SntpClient, SynchronizationError, SynchronizationResult};
+use rsntp::{Config, ReferenceIdentifier, SntpClient, SynchronizationError, SynchronizationResult,AsyncSntpClient};
 use std::net::{IpAddr, Ipv6Addr, SocketAddr, ToSocketAddrs};
 use std::process;
+use futures::future::join_all;
 
 #[derive(Parser, Debug)]
 #[command(name = "rkik")]
@@ -24,7 +25,7 @@ pub struct Args {
     pub server: Option<String>,
 
     /// Compare two servers
-    #[arg(short='C',long, num_args = 2)]
+    #[arg(short='C',long, num_args = 2..10)]
     pub compare: Option<Vec<String>>,
 
     /// Show detailed output
@@ -208,94 +209,107 @@ pub fn query_server(server: &str, term: &Term, args: &Args) {
     }
 }
 
-pub fn compare_servers(server1: &str, server2: &str, term: &Term, args: &Args) {
-    let ip1 = match resolve_ip_for_mode(server1, args.ipv6) {
-        Ok(ip) => ip,
-        Err(e) => {
-            term.write_line(&style(format!("Error: {}", e)).red().to_string())
-                .unwrap();
-            process::exit(1);
-        }
+pub async fn compare_servers(servers: &[String], term: &Term, args: &Args) {
+    if servers.len() < 2 {
+        term.write_line(&style("Need at least 2 servers to compare").red().to_string()).unwrap();
+        return;
+    }
+
+    let resolved: Vec<_> = servers.iter()
+        .map(|s| (s.clone(), resolve_ip_for_mode(s, args.ipv6)))
+        .collect();
+
+    let valid: Vec<_> = resolved.iter()
+        .filter_map(|(name, ip)| match ip {
+            Ok(addr) => Some((name.clone(), *addr)),
+            Err(e) => {
+                term.write_line(&style(format!("Could not resolve {}: {}", name, e)).red().to_string()).ok();
+                None
+            }
+        })
+        .collect();
+
+    if valid.len() < 2 {
+        term.write_line(&style("Not enough valid servers to compare.").red().to_string()).unwrap();
+        return;
+    }
+
+    let client = {
+        let config = if args.ipv6 {
+            Config::default().bind_address((Ipv6Addr::UNSPECIFIED, 0).into())
+        } else {
+            Config::default().bind_address(([0, 0, 0, 0], 0).into())
+        };
+        AsyncSntpClient::with_config(config)
     };
-    let ip2 = match resolve_ip_for_mode(server2, args.ipv6) {
-        Ok(ip) => ip,
-        Err(e) => {
-            term.write_line(&style(format!("Error: {}", e)).red().to_string())
-                .unwrap();
-            process::exit(1);
-        }
-    };
 
-    let client = client_for_mode(args.ipv6);
-    let result1 = synchronize_with_ip(&client, ip1);
-    let result2 = synchronize_with_ip(&client, ip2);
+    let futures = valid.iter()
+        .map(|(_, ip)| client.synchronize(SocketAddr::new(*ip, 123).to_string()))
+        .collect::<Vec<_>>();
 
-    match (result1, result2) {
-        (Ok(r1), Ok(r2)) => {
-            let offset1 = r1.clock_offset().as_secs_f64() * 1000.0;
-            let offset2 = r2.clock_offset().as_secs_f64() * 1000.0;
-            let diff = (offset1 - offset2).abs();
-            let ip_version1 = if ip1.is_ipv6() { "v6" } else { "v4" };
-            let ip_version2 = if ip2.is_ipv6() { "v6" } else { "v4" };
+    let results = join_all(futures).await;
 
-            if args.format == "json" {
-                println!(
-                    "{{\
-                        \"server1\": \"{}\", \
-                        \"ip1\": \"{}\", \
-                        \"ip_version1\": \"{}\", \
-                        \"offset1_ms\": {:.3}, \
-                        \"server2\": \"{}\", \
-                        \"ip2\": \"{}\", \
-                        \"ip_version2\": \"{}\", \
-                        \"offset2_ms\": {:.3}, \
-                        \"difference_ms\": {:.3}\
-                    }}",
-                    server1, ip1, ip_version1, offset1, server2, ip2, ip_version2, offset2, diff
-                );
-            } else {
-                term.write_line(&format!(
-                    "{} {} and {}",
-                    style("Comparing").bold(),
-                    style(server1).yellow(),
-                    style(server2).yellow()
-                ))
-                .unwrap();
-                term.write_line(&format!(
-                    "{} [{} {}]: {:.3} ms",
-                    style(server1).green(),
-                    ip1,
-                    ip_version1,
-                    offset1
-                ))
-                .unwrap();
-                term.write_line(&format!(
-                    "{} [{} {}]: {:.3} ms",
-                    style(server2).green(),
-                    ip2,
-                    ip_version2,
-                    offset2
-                ))
-                .unwrap();
-                term.write_line(&format!(
-                    "{} {:.3} ms",
-                    style("Difference:").cyan().bold(),
-                    diff
-                ))
-                .unwrap();
+    let mut final_results = vec![];
+
+    for ((name, ip), res) in valid.iter().zip(results) {
+        match res {
+            Ok(r) => {
+                let offset = r.clock_offset().as_secs_f64() * 1000.0;
+                final_results.push((name.clone(), *ip, offset));
+            }
+            Err(e) => {
+                term.write_line(&style(format!("Failed to query {}: {}", name, e)).red().to_string()).ok();
             }
         }
-        (Err(e1), Err(e2)) => term
-            .write_line(&format!(
-                "Error querying '{}': {}\nError querying '{}': {}",
-                server1, e1, server2, e2
-            ))
-            .unwrap(),
-        (Err(e), _) => term
-            .write_line(&format!("Error querying '{}': {}", server1, e))
-            .unwrap(),
-        (_, Err(e)) => term
-            .write_line(&format!("Error querying '{}': {}", server2, e))
-            .unwrap(),
+    }
+
+    if final_results.len() < 2 {
+        term.write_line(&style("At least two successful responses required to compare.").red().to_string()).unwrap();
+        return;
+    }
+
+    if args.format == "json" {
+        println!("[");
+        for (i, (name, ip, offset)) in final_results.iter().enumerate() {
+            println!(
+                "  {{ \"server\": \"{}\", \"ip\": \"{}\", \"offset_ms\": {:.3} }}{}",
+                name,
+                ip,
+                offset,
+                if i < final_results.len() - 1 { "," } else { "" }
+            );
+        }
+        println!("]");
+    } else {
+        term.write_line(&format!(
+            "{} {} servers",
+            style("Comparing (async):").bold(),
+            final_results.len()
+        )).unwrap();
+
+        for (name, ip, offset) in final_results.iter() {
+            let ip_version = if ip.is_ipv6() { "v6" } else { "v4" };
+            term.write_line(&format!(
+                "{} [{} {}]: {:.3} ms",
+                style(name).green(),
+                ip,
+                ip_version,
+                offset
+            )).unwrap();
+        }
+
+        let min = final_results.iter().map(|(_, _, o)| *o).fold(f64::INFINITY, f64::min);
+        let max = final_results.iter().map(|(_, _, o)| *o).fold(f64::NEG_INFINITY, f64::max);
+        let avg = final_results.iter().map(|(_, _, o)| *o).sum::<f64>() / final_results.len() as f64;
+        let diff = max - min;
+
+        term.write_line(&format!(
+            "{} {:.3} ms (min: {:.3}, max: {:.3}, avg: {:.3})",
+            style("Max drift:").cyan().bold(),
+            diff,
+            min,
+            max,
+            avg
+        )).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,4 +28,3 @@ async fn main() {
         }
     }
 }
-

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,14 @@ use std::process;
 
 use rkik::{Args, compare_servers, query_server};
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args = Args::parse();
     let term = Term::stdout();
 
     match (&args.compare, &args.server, &args.positional) {
-        (Some(servers), _, _) if servers.len() == 2 => {
-            compare_servers(&servers[0], &servers[1], &term, &args)
+        (Some(servers), _, _) if servers.len() >= 2 => {
+            compare_servers(&servers, &term, &args).await;
         }
         (_, Some(server), _) => query_server(server, &term, &args),
         (_, None, Some(pos)) => query_server(pos, &term, &args),
@@ -22,8 +23,9 @@ fn main() {
                     .bold()
                     .to_string(),
             )
-            .unwrap();
+                .unwrap();
             process::exit(1);
         }
     }
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ async fn main() {
 
     match (&args.compare, &args.server, &args.positional) {
         (Some(servers), _, _) if servers.len() >= 2 => {
-            compare_servers(&servers, &term, &args).await;
+            compare_servers(servers, &term, &args).await;
         }
         (_, Some(server), _) => query_server(server, &term, &args),
         (_, None, Some(pos)) => query_server(pos, &term, &args),

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -1,7 +1,5 @@
 use assert_cmd::Command;
-use predicates::prelude::*;
 use predicates::str::contains;
-use rkik::resolve_ip_for_mode;
 
 #[cfg(feature = "network-tests")]
 #[test]


### PR DESCRIPTION
Implementation of an AsyncSntpCLient to manage parallel asynchronous ntp request in the objective to compare X servers together. 

We can now use rkik -C ntp1 ntp2 ntp3 ..... 

By default, rkik does now use an asynchronous client whenever we want to compare servers.


That is the kind of output we will get using this : 

Comparing (async): 5 servers
1.pool.ntp.org [188.165.49.6 v4]: 2.237 ms
2.pool.ntp.org [193.200.43.105 v4]: 2.144 ms
3.pool.ntp.org [82.67.62.62 v4]: 1.507 ms
fr.pool.ntp.org [129.151.225.244 v4]: 2.961 ms
hv2.dona.bzh [147.135.213.183 v4]: 10800002.497 ms
Max drift: 10800000.991 ms (min: 1.507, max: 10800002.497, avg: 2160002.269)

