### PR TITLE
Add repeated query stats and infinite loop handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +755,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rsntp = "4.0.0"
 clap = { version = "4.5", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 console = "0.15"
-tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "net"] }
+tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "net", "signal"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/src/fmt/text.rs
+++ b/src/fmt/text.rs
@@ -1,4 +1,5 @@
 use crate::domain::ntp::ProbeResult;
+use crate::stats::Stats;
 use console::style;
 
 /// Render a probe result into human readable text with the legacy style.
@@ -115,4 +116,35 @@ pub fn render_compare(results: &[ProbeResult], verbose: bool) -> String {
     ));
 
     out
+}
+
+/// Render a minimal line for a probe result.
+pub fn render_short_probe(r: &ProbeResult) -> String {
+    format!(
+        "{name} {offset:.3} ms",
+        name = r.target.name,
+        offset = r.offset_ms
+    )
+}
+
+/// Render a minimal line for comparison results.
+pub fn render_short_compare(results: &[ProbeResult]) -> String {
+    results
+        .iter()
+        .map(|r| format!("{name}:{off:.3}", name = r.target.name, off = r.offset_ms))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render statistics for a set of probe results.
+pub fn render_stats(name: &str, stats: &Stats) -> String {
+    format!(
+        "{name}: avg {avg:.3} ms (min {min:.3}, max {max:.3}) rtt {rtt:.3} ms over {cnt}",
+        name = name,
+        avg = stats.offset_avg,
+        min = stats.offset_min,
+        max = stats.offset_max,
+        rtt = stats.rtt_avg,
+        cnt = stats.count
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod domain;
 mod error;
 pub mod fmt;
 pub mod services;
+pub mod stats;
 
 pub use domain::ntp::{ProbeResult, Target};
 pub use error::RkikError;

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,31 @@
+use crate::domain::ntp::ProbeResult;
+
+#[derive(Debug, Clone)]
+pub struct Stats {
+    pub count: usize,
+    pub offset_avg: f64,
+    pub offset_min: f64,
+    pub offset_max: f64,
+    pub rtt_avg: f64,
+}
+
+pub fn compute_stats(results: &[ProbeResult]) -> Stats {
+    let count = results.len();
+    let offset_avg = results.iter().map(|r| r.offset_ms).sum::<f64>() / count as f64;
+    let offset_min = results
+        .iter()
+        .map(|r| r.offset_ms)
+        .fold(f64::INFINITY, f64::min);
+    let offset_max = results
+        .iter()
+        .map(|r| r.offset_ms)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let rtt_avg = results.iter().map(|r| r.rtt_ms).sum::<f64>() / count as f64;
+    Stats {
+        count,
+        offset_avg,
+        offset_min,
+        offset_max,
+        rtt_avg,
+    }
+}


### PR DESCRIPTION
## Summary
- support repeated queries with concise per-request output and final statistics
- allow `--count`/`--infinite` with `--compare` and report stats per server
- handle Ctrl-C in infinite mode and expose stats helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ac83be65908328a6f26e891c7b3069