### PR TITLE
Feat/diag tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ pub enum RkikError {
 ```
 
 - JSON integration improved
-We now use serde_json for the format of the JSON output(thanks @lucy_dot_dot), which has changed, making the use of the verbose flag on it actually very useful, you can now use
+We now use serde_json for the format of the JSON output(thanks @lucy-dot-dot), which has changed, making the use of the verbose flag on it actually very useful, you can now use
 ```bash
 rkik -jp time.google.com
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,65 @@
+# RKIK - Changelog 
+
+## Unreleased
+- Optional --sync flag to actually apply the time from a distant server to our system ( Unix only, needs root )
+
+- New --count --infinite --interval flags for continuous monitoring of the server
+
+- API Integration
+Everybody can now really use rkik as a library for their projects. The format / output part is now dissociated with the core of the app.
+
+- --version flag
+You can now display the installed version of rkik using -V or --version.
+
+- More detailled errors 
+Errors output is now more detailed, more precise and prettier. It follows this RkikError enuum
+```rust
+pub enum RkikError {
+    /// DNS resolution failure.
+    #[error("dns: {0}")]
+    Dns(String),
+    /// Network related error.
+    #[error("network: {0}")]
+    Network(String),
+    /// Protocol violation.
+    #[error("protocol: {0}")]
+    Protocol(String),
+    /// Underlying IO error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    /// Other error cases.
+    #[error("other: {0}")]
+    Other(String),
+}
+```
+
+- JSON integration improved
+We now use serde_json for the format of the JSON output(thanks @lucy_dot_dot), which has changed, making the use of the verbose flag on it actually very useful, you can now use
+```bash
+rkik -jp time.google.com
+```
+To display a pretty json output. 
+```json
+{
+  "schema_version": 1,
+  "run_ts": "2025-08-26T15:46:54.558275110+00:00",
+  "results": [
+    {
+      "name": "time.google.com",
+      "ip": "216.239.35.8",
+      "offset_ms": 1.4152181101962924,
+      "rtt_ms": 12.369429459795356,
+      "utc": "2025-08-26T15:46:54.559491539+00:00",
+      "local": "2025-08-26 17:46:54"
+    }
+  ]
+}
+```
+
+- no color format integration
+We've added the `--nocolor` arg for the output to not be stylized, otherwise, il will always be if your terminal can handle it.
+
+- Short output format
+You can now use `--format simple` or `-S` / `--short` to display a minimalist output with only the time of the requested server and its IP address.
+
+## Latest version v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,7 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rkik"
-version = "0.6.0"
+version = "1.0.0"
 dependencies = [
  "assert_cmd",
  "atty",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,6 +678,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +755,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ rsntp = "4.0.0"
 clap = { version = "4.5", features = ["derive"] }
 chrono = { version = "0.4", features = ["serde"] }
 console = "0.15"
-tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "net"] }
+tokio = { version = "1.45.0", features = ["macros", "rt-multi-thread", "net", "signal"] }
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -89,15 +89,20 @@ Round Trip Delay: 2.320 ms
 **JSON:**
 ```json
 {
-  "server": "time.google.com",
-  "ip": "216.239.35.0",
-  "utc_time": "2024-05-27T13:45:00Z",
-  "local_time": "2024-05-27 15:45:00",
-  "offset_ms": -1.203,
-  "rtt_ms": 2.320,
-  "stratum": 1,
-  "reference_id": "GOOG"
+  "schema_version": 1,
+  "run_ts": "2025-08-25T15:40:43.774174713+00:00",
+  "results": [
+    {
+      "name": "time.google.com",
+      "ip": "216.239.35.8",
+      "offset_ms": 0.16905309166759253,
+      "rtt_ms": 12.1621775906533,
+      "utc": "2025-08-25T15:40:43.774244589+00:00",
+      "local": "2025-08-25 17:40:43"
+    }
+  ]
 }
+
 ```
 
 ---

--- a/src/bin/rkik.rs
+++ b/src/bin/rkik.rs
@@ -12,6 +12,7 @@ use rkik::{ProbeResult, RkikError, compare_many, fmt, query_one};
 enum OutputFormat {
     Text,
     Json,
+    Simple,
 }
 
 #[derive(Parser, Debug)]
@@ -32,7 +33,7 @@ struct Args {
     pub verbose: bool,
 
     /// Output format: text or json
-    #[arg(short, long, default_value = "text", value_enum)] // ← value_enum explicite
+    #[arg(short = 'f', long, default_value = "text", value_enum)]
     format: OutputFormat,
 
     /// Alias for JSON output
@@ -69,9 +70,12 @@ struct Args {
     infinite: bool,
 
     /// Interval between queries in seconds (only with --infinite or --count)
-    #[arg(short = 'i', long, default_value_t = 10)]
+    #[arg(short = 'i', long, default_value_t = 1)]
     interval: u64,
     
+    /// Specific count of requests 
+    #[arg(short = 'c', long, default_value_t = 1)]
+    count: u32,
 }
 
 #[tokio::main]

--- a/src/bin/rkik.rs
+++ b/src/bin/rkik.rs
@@ -36,11 +36,11 @@ struct Args {
     format: OutputFormat,
 
     /// Alias for JSON output
-    #[arg(long)]
+    #[arg(short = 'j', long)]
     json: bool,
 
     /// Pretty-print JSON
-    #[arg(long)]
+    #[arg(short = 'p', long)]
     pretty: bool,
 
     /// Disable colored output
@@ -63,6 +63,15 @@ struct Args {
     /// Positional server name or IP
     #[arg(index = 1)]
     positional: Option<String>,
+
+    /// Infinite count mode
+    #[arg(short = '8', long)]
+    infinite: bool,
+
+    /// Interval between queries in seconds (only with --infinite or --count)
+    #[arg(short = 'i', long, default_value_t = 10)]
+    interval: u64,
+    
 }
 
 #[tokio::main]
@@ -208,7 +217,7 @@ fn output(term: &Term, results: &[ProbeResult], fmt: OutputFormat, pretty: bool,
                 term.write_line(&s).ok();
             }
         }
-        OutputFormat::Json => match fmt::json::to_json(results, pretty) {
+        OutputFormat::Json => match fmt::json::to_json(results, pretty,verbose) {
             Ok(s) => println!("{}", s),
             Err(e) => eprintln!("error serializing: {}", e),
         },

--- a/src/bin/rkik.rs
+++ b/src/bin/rkik.rs
@@ -16,6 +16,7 @@ enum OutputFormat {
 
 #[derive(Parser, Debug)]
 #[command(name = "rkik")]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "Rusty Klock Inspection Kit - NTP Query and Compare Tool")]
 struct Args {
     /// Query a single NTP server

--- a/src/domain/ntp.rs
+++ b/src/domain/ntp.rs
@@ -23,4 +23,5 @@ pub struct ProbeResult {
     pub ref_id: String,
     pub utc: DateTime<Utc>,
     pub local: DateTime<Local>,
+    pub timestamp: i64, // Unix timestamp
 }

--- a/src/fmt/text.rs
+++ b/src/fmt/text.rs
@@ -121,9 +121,9 @@ pub fn render_compare(results: &[ProbeResult], verbose: bool) -> String {
 /// Render a minimal line for a probe result.
 pub fn render_short_probe(r: &ProbeResult) -> String {
     format!(
-        "{name} {offset:.3} ms",
-        name = r.target.name,
-        offset = r.offset_ms
+        "{name} {offset}",
+        name = style(&r.target.name).green(),
+        offset = style(format!("{:.3} ms", r.offset_ms)).yellow()
     )
 }
 
@@ -131,7 +131,14 @@ pub fn render_short_probe(r: &ProbeResult) -> String {
 pub fn render_short_compare(results: &[ProbeResult]) -> String {
     results
         .iter()
-        .map(|r| format!("{name}:{off:.3}", name = r.target.name, off = r.offset_ms))
+        .map(|r| {
+            format!(
+                "{name}:{off}",
+                name = style(&r.target.name).green(),
+                off = style(format!("{:.3}", r.offset_ms)).yellow()
+            )
+        })
+==
         .collect::<Vec<_>>()
         .join(" ")
 }
@@ -147,4 +154,18 @@ pub fn render_stats(name: &str, stats: &Stats) -> String {
         rtt = stats.rtt_avg,
         cnt = stats.count
     )
+}
+
+/// Render a probe in simple mode (timestamp and IP only).
+pub fn render_simple_probe(r: &ProbeResult) -> String {
+    format!("{} {}", r.utc.to_rfc3339(), r.target.ip)
+}
+
+/// Render multiple probes in simple mode.
+pub fn render_simple_compare(results: &[ProbeResult]) -> String {
+    results
+        .iter()
+        .map(render_simple_probe)
+        .collect::<Vec<_>>()
+        .join("\n")
 }

--- a/src/fmt/text.rs
+++ b/src/fmt/text.rs
@@ -6,7 +6,6 @@ use console::style;
 pub fn render_probe(r: &ProbeResult, verbose: bool) -> String {
     let ip_version = if r.target.ip.is_ipv6() { "v6" } else { "v4" };
 
-    // bloc principal (strictement identique au rendu legacy)
     let mut out = format!(
         "{srv_lbl} {srv_val}\n\
          {ip_lbl} {ip_val} ({ver})\n\
@@ -29,14 +28,14 @@ pub fn render_probe(r: &ProbeResult, verbose: bool) -> String {
         rtt_val = r.rtt_ms,
     );
 
-    // bloc verbose : lignes additionnelles Stratum / Reference ID
     if verbose {
         out.push_str(&format!(
-            "\n{str_lbl} {str_val}\n{ref_lbl} {ref_val}",
+            "\n{str_lbl} {str_val}\n{ref_lbl} {ref_val}\n Timestamp: {timestamp}",
             str_lbl = style("Stratum:").cyan().bold(),
             str_val = r.stratum,
             ref_lbl = style("Reference ID:").cyan().bold(),
-            ref_val = r.ref_id
+            ref_val = r.ref_id,
+            timestamp = r.timestamp
         ));
     }
 
@@ -136,7 +135,6 @@ pub fn render_short_compare(results: &[ProbeResult]) -> String {
                 "{name}:{off}",
                 name = style(&r.target.name).green(),
                 off = style(format!("{:.3}", r.offset_ms)).yellow()
-                
             )
         })
         .collect::<Vec<_>>()
@@ -145,27 +143,33 @@ pub fn render_short_compare(results: &[ProbeResult]) -> String {
 
 /// Render statistics for a set of probe results
 pub fn render_stats(name: &str, stats: &Stats) -> String {
-    fn fmt_ms(v: f64) -> String { format!("{:.3} ms", v) }
+    fn fmt_ms(v: f64) -> String {
+        format!("{:.3} ms", v)
+    }
 
     format!(
         "\n{n}: {avg_lbl} {avg} ({min_lbl} {min}, {max_lbl} {max}) {rtt_lbl} {rtt} ({cnt} {rqst})",
-        n        = style(name).green().bold(),
-        avg_lbl  = style("avg").cyan().bold(),
-        avg      = style(fmt_ms(stats.offset_avg)).green(),
-        min_lbl  = style("min").cyan().bold(),
-        min      = style(fmt_ms(stats.offset_min)).green(),
-        max_lbl  = style("max").cyan().bold(),
-        max      = style(fmt_ms(stats.offset_max)).green(),
-        rtt_lbl  = style("rtt").cyan().bold(),
-        rtt      = style(fmt_ms(stats.rtt_avg)).green(),
-        cnt      = style(stats.count).green(),
-        rqst     = style("requests").green(),
+        n = style(name).green().bold(),
+        avg_lbl = style("avg").cyan().bold(),
+        avg = style(fmt_ms(stats.offset_avg)).green(),
+        min_lbl = style("min").cyan().bold(),
+        min = style(fmt_ms(stats.offset_min)).green(),
+        max_lbl = style("max").cyan().bold(),
+        max = style(fmt_ms(stats.offset_max)).green(),
+        rtt_lbl = style("rtt").cyan().bold(),
+        rtt = style(fmt_ms(stats.rtt_avg)).green(),
+        cnt = style(stats.count).green(),
+        rqst = style("requests").green(),
     )
 }
 
-/// Render a probe in simple mode (timestamp and IP only).
+/// Render a probe in simple mode (offset and IP only).
 pub fn render_simple_probe(r: &ProbeResult) -> String {
-    format!("{} {}", r.utc.to_rfc3339(), r.target.ip)
+    format!(
+        "{name} {offset}",
+        name = style(&r.target.name).green(),
+        offset = style(format!("{:.3} ms", r.offset_ms)).yellow()
+    )
 }
 
 /// Render multiple probes in simple mode.

--- a/src/fmt/text.rs
+++ b/src/fmt/text.rs
@@ -136,23 +136,30 @@ pub fn render_short_compare(results: &[ProbeResult]) -> String {
                 "{name}:{off}",
                 name = style(&r.target.name).green(),
                 off = style(format!("{:.3}", r.offset_ms)).yellow()
+                
             )
         })
-==
         .collect::<Vec<_>>()
         .join(" ")
 }
 
-/// Render statistics for a set of probe results.
+/// Render statistics for a set of probe results
 pub fn render_stats(name: &str, stats: &Stats) -> String {
+    fn fmt_ms(v: f64) -> String { format!("{:.3} ms", v) }
+
     format!(
-        "{name}: avg {avg:.3} ms (min {min:.3}, max {max:.3}) rtt {rtt:.3} ms over {cnt}",
-        name = name,
-        avg = stats.offset_avg,
-        min = stats.offset_min,
-        max = stats.offset_max,
-        rtt = stats.rtt_avg,
-        cnt = stats.count
+        "\n{n}: {avg_lbl} {avg} ({min_lbl} {min}, {max_lbl} {max}) {rtt_lbl} {rtt} ({cnt} {rqst})",
+        n        = style(name).green().bold(),
+        avg_lbl  = style("avg").cyan().bold(),
+        avg      = style(fmt_ms(stats.offset_avg)).green(),
+        min_lbl  = style("min").cyan().bold(),
+        min      = style(fmt_ms(stats.offset_min)).green(),
+        max_lbl  = style("max").cyan().bold(),
+        max      = style(fmt_ms(stats.offset_max)).green(),
+        rtt_lbl  = style("rtt").cyan().bold(),
+        rtt      = style(fmt_ms(stats.rtt_avg)).green(),
+        cnt      = style(stats.count).green(),
+        rqst     = style("requests").green(),
     )
 }
 

--- a/src/fmt/text.rs
+++ b/src/fmt/text.rs
@@ -1,4 +1,5 @@
 use crate::domain::ntp::ProbeResult;
+use crate::stats::Stats;
 use console::style;
 
 /// Render a probe result into human readable text with the legacy style.
@@ -115,4 +116,35 @@ pub fn render_compare(results: &[ProbeResult], verbose: bool) -> String {
     ));
 
     out
+}
+
+/// Render a minimal line for a probe result.
+pub fn render_short_probe(r: &ProbeResult) -> String {
+    format!(
+        "{name} {offset:.3} ms",
+        name = r.target.name,
+        offset = r.offset_ms
+    )
+}
+
+/// Render a minimal line for comparison results.
+pub fn render_short_compare(results: &[ProbeResult]) -> String {
+    results
+        .iter()
+        .map(|r| format!("{name}:{off:.3}", name = r.target.name, off = r.offset_ms))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Render statistics for a set of probe results.
+pub fn render_stats(name: &str, stats: &Stats) -> String {
+    format!(
+        "{name}: avg {avg:.3} ms (min {min:.3}, max {max:.3}) rtt {rtt:.3} ms over {cnt}",
+        name = name,
+        avg = stats.offset_avg,
+        min = stats.offset_min,
+        max = stats.offset_max,
+        rtt = stats.rtt_avg,
+        cnt = stats.count
+    )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod domain;
 mod error;
 pub mod fmt;
 pub mod services;
+pub mod stats;
 
 pub use domain::ntp::{ProbeResult, Target};
 pub use error::RkikError;

--- a/src/services/query.rs
+++ b/src/services/query.rs
@@ -25,6 +25,7 @@ pub async fn query_one(
     let rtt_ms = res.round_trip_delay().as_secs_f64() * 1000.0;
     let stratum = res.stratum();
     let ref_id = format_reference_id(res.reference_identifier());
+    let timestamp = utc.timestamp();
     Ok(ProbeResult {
         target: Target {
             name: target.to_string(),
@@ -36,6 +37,7 @@ pub async fn query_one(
         ref_id,
         utc,
         local,
+        timestamp,
     })
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,31 @@
+use crate::domain::ntp::ProbeResult;
+
+#[derive(Debug, Clone)]
+pub struct Stats {
+    pub count: usize,
+    pub offset_avg: f64,
+    pub offset_min: f64,
+    pub offset_max: f64,
+    pub rtt_avg: f64,
+}
+
+pub fn compute_stats(results: &[ProbeResult]) -> Stats {
+    let count = results.len();
+    let offset_avg = results.iter().map(|r| r.offset_ms).sum::<f64>() / count as f64;
+    let offset_min = results
+        .iter()
+        .map(|r| r.offset_ms)
+        .fold(f64::INFINITY, f64::min);
+    let offset_max = results
+        .iter()
+        .map(|r| r.offset_ms)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let rtt_avg = results.iter().map(|r| r.rtt_ms).sum::<f64>() / count as f64;
+    Stats {
+        count,
+        offset_avg,
+        offset_min,
+        offset_max,
+        rtt_avg,
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,6 +1,9 @@
 use crate::domain::ntp::ProbeResult;
+#[cfg(feature = "json")]
+use serde::Serialize;
 
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "json", derive(Serialize))]
 pub struct Stats {
     pub count: usize,
     pub offset_avg: f64,


### PR DESCRIPTION

- New --count --infinite --interval flags for continuous monitoring of the server either with short, JSOn or text ouput

- Short output mode with only IP and Offset

- Timestamp in verbose mode either in JSON or Text output mode

- no color format integration
We've added the `--nocolor` arg for the output to not be stylized, otherwise, il will always be if your terminal can handle it.

- Short output format
You can now use `--format simple` or `-S` / `--short` to display a minimalist output with only the time of the requested server and its IP address.