### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-test-n-build.yml
+++ b/.github/workflows/ci-test-n-build.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aguacero7/rkik/security/code-scanning/2](https://github.com/aguacero7/rkik/security/code-scanning/2)

The best way to fix the problem is to add a `permissions:` block to the workflow or to the specific job, limiting the GITHUB_TOKEN to only the privileges required for this type of CI workflow. Since this workflow only needs to check out code and run Rust commands (no need for write access), the minimal required permission is `contents: read`. This can be set either at the workflow level (top of the file, after the `name:` and `on:` section), which will apply to all jobs unless they specify their own permissions, or specifically for the `build-test-audit` job. It is general best practice to set it at the workflow level unless individual jobs need differing permissions.

To implement this:
- Edit `.github/workflows/ci-test-n-build.yml`.
- Insert `permissions: contents: read` immediately after the `name: CI` and before the `on:` block (generally after line 1 and before line 3).

No imports or additional changes are required, as this is a pure YAML configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
