### PR TITLE
feat: add verbose version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # RKIK - Changelog
 
 ## [Unreleased]
+### Added
+- **Verbose `--version` output**: `rkik --version` now shows compiled features, target platform, and Rust compiler version
+
 ---
 ## [2.1.0] - 2026-01-24
 ### Added

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,34 @@
+fn main() {
+    let mut features = vec![];
+    if std::env::var("CARGO_FEATURE_JSON").is_ok() {
+        features.push("json");
+    }
+    if std::env::var("CARGO_FEATURE_NTS").is_ok() {
+        features.push("nts");
+    }
+    if std::env::var("CARGO_FEATURE_PTP").is_ok() {
+        features.push("ptp");
+    }
+    if std::env::var("CARGO_FEATURE_SYNC").is_ok() {
+        features.push("sync");
+    }
+
+    let features_str = if features.is_empty() {
+        "none".to_string()
+    } else {
+        features.join(", ")
+    };
+    println!("cargo:rustc-env=RKIK_FEATURES={}", features_str);
+
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=RKIK_TARGET={}", target);
+
+    let rustc_ver = std::process::Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.split_whitespace().nth(1).map(|v| v.to_string()))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=RKIK_RUSTC_VERSION={}", rustc_ver);
+}

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,21 @@
 fn main() {
-    let mut features = vec![];
-    if std::env::var("CARGO_FEATURE_JSON").is_ok() {
-        features.push("json");
-    }
-    if std::env::var("CARGO_FEATURE_NTS").is_ok() {
-        features.push("nts");
-    }
-    if std::env::var("CARGO_FEATURE_PTP").is_ok() {
-        features.push("ptp");
-    }
-    if std::env::var("CARGO_FEATURE_SYNC").is_ok() {
-        features.push("sync");
-    }
+    let mut features: Vec<String> = std::env::vars()
+        .filter_map(|(key, _)| {
+            const PREFIX: &str = "CARGO_FEATURE_";
+            if let Some(stripped) = key.strip_prefix(PREFIX) {
+                // Match cargo feature names by normalizing env var fragment:
+                //   CARGO_FEATURE_JSON  -> "json"
+                //   CARGO_FEATURE_SOME_FEATURE -> "some_feature"
+                Some(stripped.to_ascii_lowercase())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    // Ensure deterministic ordering regardless of env var ordering
+    features.sort();
+    features.dedup();
 
     let features_str = if features.is_empty() {
         "none".to_string()

--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,13 @@
 fn main() {
-    let mut features = vec![];
-    if std::env::var("CARGO_FEATURE_JSON").is_ok() {
-        features.push("json");
-    }
-    if std::env::var("CARGO_FEATURE_NTS").is_ok() {
-        features.push("nts");
-    }
-    if std::env::var("CARGO_FEATURE_PTP").is_ok() {
-        features.push("ptp");
-    }
-    if std::env::var("CARGO_FEATURE_SYNC").is_ok() {
-        features.push("sync");
-    }
+    let mut features: Vec<String> = std::env::vars()
+        .filter_map(|(key, _)| {
+            const PREFIX: &str = "CARGO_FEATURE_";
+            key.strip_prefix(PREFIX)
+                .map(|stripped| stripped.to_ascii_lowercase())
+        })
+        .collect();
+    features.sort();
+    features.dedup();
 
     let features_str = if features.is_empty() {
         "none".to_string()
@@ -23,7 +19,8 @@ fn main() {
     let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
     println!("cargo:rustc-env=RKIK_TARGET={}", target);
 
-    let rustc_ver = std::process::Command::new("rustc")
+    let rustc = std::env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let rustc_ver = std::process::Command::new(rustc)
         .arg("--version")
         .output()
         .ok()

--- a/src/bin/rkik.rs
+++ b/src/bin/rkik.rs
@@ -12,6 +12,12 @@ use std::process::{self, Command as ProcessCommand};
 #[derive(Parser, Debug)]
 #[command(name = "rkik")]
 #[command(version = env!("CARGO_PKG_VERSION"))]
+#[command(long_version = concat!(
+    env!("CARGO_PKG_VERSION"), "\n",
+    "Features: ", env!("RKIK_FEATURES"), "\n",
+    "Platform: ", env!("RKIK_TARGET"), "\n",
+    "Rust:     ", env!("RKIK_RUSTC_VERSION")
+))]
 #[command(about = "Rusty Klock Inspection Kit - NTP Query and Compare Tool")]
 struct Cli {
     #[command(subcommand)]

--- a/src/bin/rkik/legacy.rs
+++ b/src/bin/rkik/legacy.rs
@@ -47,11 +47,7 @@ impl std::fmt::Display for OutputFormat {
 
 #[derive(Parser, Debug, Clone)]
 #[command(name = "rkik")]
-#[command(version = env!("CARGO_PKG_/// The above code appears to be a comment block in Rust. In Rust,
-/// comments are denoted by `/*` to start a block comment and `*/`
-/// to end it. Comments are ignored by the compiler and are used to
-/// provide explanations or notes within the code for developers.
-VERSION"))]
+#[command(version = env!("CARGO_PKG_VERSION"))]
 #[command(about = "Rusty Klock Inspection Kit - NTP Query and Compare Tool")]
 pub struct LegacyArgs {
     /// Query a single NTP server (optional)


### PR DESCRIPTION
This PR only adds a build script to store data on the compilation variables, its goal is to show a verbose version output, see the issue linked.

## Summary by Sourcery

Add verbose version reporting for the rkik binary using build-time metadata.

New Features:
- Extend rkik's version command with a long/verbose output including enabled features, target platform, and Rust compiler version.

Enhancements:
- Introduce a build script to capture enabled Cargo features, compilation target, and Rust compiler version as environment variables for use at runtime.

Documentation:
- Document the new verbose --version output behavior in the Unreleased section of the changelog.