### PR TITLE
Diplaying errors when using --plugin flag with conflicting flags

### DIFF
--- a/src/bin/rkik/legacy.rs
+++ b/src/bin/rkik/legacy.rs
@@ -216,13 +216,6 @@ pub async fn run(mut args: LegacyArgs, _warn_legacy: bool) {
     if args.short && args.json {
         args.format = OutputFormat::JsonShort;
     }
-    // colors
-    let want_color = (matches!(args.format, OutputFormat::Text)
-        || matches!(args.format, OutputFormat::Simple))
-        && io::stdout().is_terminal()
-        && std::env::var_os("NO_COLOR").is_none()
-        && !args.no_color;
-    set_colors_enabled(want_color);
 
     let term = Term::stdout();
     let timeout = Duration::from_secs_f64(args.timeout);
@@ -324,17 +317,88 @@ pub async fn run(mut args: LegacyArgs, _warn_legacy: bool) {
         process::exit(2);
     }
 
-    // refuse --plugin with --compare for now
-    if args.plugin && args.compare.is_some() {
-        term.write_line(
-            &style("--plugin cannot be used with --compare")
-                .red()
-                .to_string(),
-        )
-        .ok();
+    //--plugin checks
+    // refuse --plugin --compare, --verbose, --json, --pretty, --short, --format(except for text), --infinte
+    if args.plugin{
+        if args.compare.is_some() {
+            term.write_line(
+                &style("--plugin cannot be used with --compare")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
+            let _ = io::stdout().flush();
+            process::exit(2);
+        }
+        if args.verbose {
+            term.write_line(
+                &style("--plugin cannot be used with --verbose")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
         let _ = io::stdout().flush();
         process::exit(2);
+        }
+        if args.json {
+            term.write_line(
+                &style("--plugin cannot be used with --json")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
+            let _ = io::stdout().flush();
+            process::exit(2);
+        }
+        if args.pretty {
+            term.write_line(
+                &style("--plugin cannot be used with --pretty")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
+            let _ = io::stdout().flush();
+            process::exit(2);
+        }
+        if args.short {
+            term.write_line(
+                &style("--plugin cannot be used with --short")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
+            let _ = io::stdout().flush();
+            process::exit(2);
+        }
+        if !matches!(args.format, OutputFormat::Text) {
+            term.write_line(
+                &style("--plugin cannot be used with --format")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
+            let _ = io::stdout().flush();
+            process::exit(2);
+        }
+        if args.infinite {
+            term.write_line(
+                &style("--plugin cannot be used with --infinite")
+                    .red()
+                    .to_string(),
+            )
+            .ok();
+            let _ = io::stdout().flush();
+            process::exit(2);
+        }
     }
+
+    // colors
+    let want_color = (matches!(args.format, OutputFormat::Text)
+        || matches!(args.format, OutputFormat::Simple))
+        && io::stdout().is_terminal()
+        && std::env::var_os("NO_COLOR").is_none()
+        && !args.no_color;
+    set_colors_enabled(want_color);
 
     // refuse --sync with --compare
     #[cfg(feature = "sync")]

--- a/src/bin/rkik/legacy.rs
+++ b/src/bin/rkik/legacy.rs
@@ -317,78 +317,28 @@ pub async fn run(mut args: LegacyArgs, _warn_legacy: bool) {
         process::exit(2);
     }
 
-    //--plugin checks
-    // refuse --plugin --compare, --verbose, --json, --pretty, --short, --format(except for text), --infinte
-    if args.plugin{
+    // refuse --plugin --compare, --verbose, --json, --pretty, --short, --format(except for text), --infinite
+    if args.plugin {
         if args.compare.is_some() {
-            term.write_line(
-                &style("--plugin cannot be used with --compare")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-            let _ = io::stdout().flush();
-            process::exit(2);
+            plugin_conflict("compare", &term);
         }
         if args.verbose {
-            term.write_line(
-                &style("--plugin cannot be used with --verbose")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-        let _ = io::stdout().flush();
-        process::exit(2);
+            plugin_conflict("verbose", &term);
         }
         if args.json {
-            term.write_line(
-                &style("--plugin cannot be used with --json")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-            let _ = io::stdout().flush();
-            process::exit(2);
+            plugin_conflict("json", &term);
         }
         if args.pretty {
-            term.write_line(
-                &style("--plugin cannot be used with --pretty")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-            let _ = io::stdout().flush();
-            process::exit(2);
+            plugin_conflict("pretty", &term);
         }
         if args.short {
-            term.write_line(
-                &style("--plugin cannot be used with --short")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-            let _ = io::stdout().flush();
-            process::exit(2);
+            plugin_conflict("short", &term);
         }
         if !matches!(args.format, OutputFormat::Text) {
-            term.write_line(
-                &style("--plugin cannot be used with --format")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-            let _ = io::stdout().flush();
-            process::exit(2);
+            plugin_conflict("format", &term);
         }
         if args.infinite {
-            term.write_line(
-                &style("--plugin cannot be used with --infinite")
-                    .red()
-                    .to_string(),
-            )
-            .ok();
-            let _ = io::stdout().flush();
-            process::exit(2);
+            plugin_conflict("infinite", &term);
         }
     }
 
@@ -1176,6 +1126,18 @@ fn handle_error(term: &Term, err: RkikError, fmt: OutputFormat, pretty: bool) ->
     } else {
         1
     }
+}
+
+//--plugin checks
+fn plugin_conflict(flag: &str, term: &Term) {
+    term.write_line(
+        &style(format!("--plugin cannot be used with --{}", flag))
+            .red()
+            .to_string(),
+    )
+    .ok();
+    let _ = io::stdout().flush();
+    process::exit(2);
 }
 
 #[cfg(feature = "sync")]


### PR DESCRIPTION
Fixes #67 
The PR has added checks for plugin flag against 
1. --verbose
2. --json
3. --pretty
4. --short
5. --infinite
6. --format (Cannot detect for text option, since it's lost in process)

All the changes have been made in `src/bin/rkik/legacy.rs` according to the suggestion mentioned in the issue itself.

PS - moved `moved_color` after the plugin check block so that it works with `--format` and `--json` flags, not sure about why it didn't work when it was declared above the validation blocks. Am unsure if it breaks anything, would really love to get feedback and review for this.

## Summary by Sourcery

Enforce incompatibility between the --plugin flag and various output and behavior flags, and adjust when color handling is configured.

Bug Fixes:
- Prevent using --plugin together with --compare, verbose, JSON, pretty, short, non-text formats, or infinite mode by printing an error and exiting early.

Enhancements:
- Move color configuration to run after plugin and flag validation to ensure color handling is consistent with the chosen output format.